### PR TITLE
save logged user data in local storage

### DIFF
--- a/src/components/context/GlobalContext.js
+++ b/src/components/context/GlobalContext.js
@@ -16,6 +16,7 @@ export function GlobalProvider({ children }) {
 		<GlobalContext.Provider
 			value={{
 				userData,
+				setUserData,
 				cartProducts,
 				updateCartProducts,
 				setCartProducts,

--- a/src/components/context/GlobalContext.js
+++ b/src/components/context/GlobalContext.js
@@ -9,7 +9,20 @@ export function GlobalProvider({ children }) {
 
 	function updateCartProducts(cartProductsArray) {
 		API.updateCart();
+		setUserData({ ...userData, cart: cartProductsArray });
+		setLocalStorage({
+			...userData,
+			user: { ...userData.user, cart: cartProductsArray },
+		});
 		setCartProducts(cartProductsArray);
+	}
+
+	function getUserFromLocalStorage() {
+		return JSON.parse(localStorage.getItem("myDrugs_user"));
+	}
+
+	function setLocalStorage(value) {
+		localStorage.setItem("myDrugs_user", JSON.stringify(value));
 	}
 
 	return (
@@ -20,6 +33,8 @@ export function GlobalProvider({ children }) {
 				cartProducts,
 				updateCartProducts,
 				setCartProducts,
+				getUserFromLocalStorage,
+				setLocalStorage,
 			}}
 		>
 			{children}

--- a/src/pages/cart/components/ProductCard.js
+++ b/src/pages/cart/components/ProductCard.js
@@ -15,7 +15,6 @@ export default function ProductCard({
 	price,
 }) {
 	const { cartProducts, setCartProducts } = useContext(GlobalContext);
-
 	function addProduct() {
 		const products = [...cartProducts];
 		products[index].quantity++;

--- a/src/pages/products/Product.js
+++ b/src/pages/products/Product.js
@@ -1,7 +1,7 @@
-import { useState } from "react/cjs/react.development";
+import { useState } from "react";
 import { Card, ProductInfo, DinamicInfo, Button, CartQuantity } from "./styles";
 import ItemCounter from "./ItemCounter";
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import GlobalContext from "../../components/context/GlobalContext";
 
 export default function Product({ id, name, description, price, image }) {
@@ -9,6 +9,14 @@ export default function Product({ id, name, description, price, image }) {
 	const [selected, setSelected] = useState(false);
 	const [quantity, setQuantity] = useState(0);
 	const [quantityInCart, setQuantityInCart] = useState(0);
+
+	useEffect(() => {
+		if (!cartProducts.length) return;
+		const productAlredyAdded = cartProducts.find(
+			(product) => product.id === id
+		);
+		if (productAlredyAdded) setQuantityInCart(productAlredyAdded.quantity);
+	}, [cartProducts]);
 
 	function select(event) {
 		if (event.target.tagName === "DIV" && selected) {

--- a/src/pages/products/Products.js
+++ b/src/pages/products/Products.js
@@ -3,8 +3,23 @@ import PageHeader from "../../components/PageHeader";
 import TopBar from "../../components/TopBar";
 import Product from "./Product";
 import productTest from "../../assets/images/productTest.png";
+import { useContext, useEffect } from "react";
+import GlobalContext from "../../components/context/GlobalContext";
 
 export default function Products() {
+	const { setCartProducts, userData, getUserFromLocalStorage } =
+		useContext(GlobalContext);
+
+	useEffect(() => {
+		const localStorage = getUserFromLocalStorage();
+		if (localStorage?.user?.cart) {
+			const storagedCart = localStorage?.user?.cart;
+			setCartProducts(storagedCart);
+		}
+
+		if (userData.user?.cart) setCartProducts(userData.user.cart);
+	}, []);
+
 	//products just for test
 	//will be replaced by database products
 	//and the page will be populated dinamically

--- a/src/pages/sign_in/SignIn.js
+++ b/src/pages/sign_in/SignIn.js
@@ -18,7 +18,8 @@ export default function SignIn() {
 
 	const [loading, setLoading] = useState(false);
 
-	const { setUserData } = useContext(GlobalContext);
+	const { setUserData, getUserFromLocalStorage, setLocalStorage } =
+		useContext(GlobalContext);
 
 	const [input, setInput] = useState({
 		user: "",
@@ -39,14 +40,6 @@ export default function SignIn() {
 			setUserData(localStoragedUser);
 		}
 	}, []);
-
-	function getUserFromLocalStorage() {
-		return JSON.parse(localStorage.getItem("myDrugs_user"));
-	}
-
-	function setLocalStorage(value) {
-		localStorage.setItem("myDrugs_user", JSON.stringify(value));
-	}
 
 	function submitForm(event) {
 		event.preventDefault();

--- a/src/pages/sign_in/SignIn.js
+++ b/src/pages/sign_in/SignIn.js
@@ -6,14 +6,20 @@ import {
 } from "../../components/Form";
 import TopBar from "../../components/TopBar";
 import { Link } from "react-router-dom";
-import { useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { cpfRegex, emailRegex } from "../sign_up/regex";
 import API from "../../services/API/requests";
 import { useNavigate } from "react-router";
 import { serverError } from "../../services/API/statusCode";
+import GlobalContext from "../../components/context/GlobalContext";
 
 export default function SignIn() {
 	const navigate = useNavigate();
+
+	const [loading, setLoading] = useState(false);
+
+	const { setUserData } = useContext(GlobalContext);
+
 	const [input, setInput] = useState({
 		user: "",
 		password: "",
@@ -24,7 +30,23 @@ export default function SignIn() {
 		emptyFields: false,
 	});
 
-	const [loading, setLoading] = useState(false);
+	useEffect(() => {
+		const localStoragedUser = getUserFromLocalStorage();
+
+		if (localStoragedUser) {
+			setLoading(false);
+			navigate("/");
+			setUserData(localStoragedUser);
+		}
+	}, []);
+
+	function getUserFromLocalStorage() {
+		return JSON.parse(localStorage.getItem("myDrugs_user"));
+	}
+
+	function setLocalStorage(value) {
+		localStorage.setItem("myDrugs_user", JSON.stringify(value));
+	}
 
 	function submitForm(event) {
 		event.preventDefault();
@@ -38,9 +60,11 @@ export default function SignIn() {
 
 		if (input.user && input.password)
 			API.signIn(body)
-				.then(() => {
+				.then((resp) => {
 					navigate("/");
 					setLoading(false);
+					setUserData(resp.data);
+					setLocalStorage(resp.data);
 				})
 				.catch((error) => {
 					if (!error.response) alert(`Application error: ${error.message}`);


### PR DESCRIPTION
Save the token and user data received from the server when signing in to localStorage. If the user already has their data saved in localStorage, they will be redirected to the home page when trying to access the /sign-in route.

Save the user's cart in localStorage and update the data of the products displayed on the home page according to what is saved in the cart if there are saved products.